### PR TITLE
Use Hanami::Events::Runner for an infinity loop

### DIFF
--- a/event_server.rb
+++ b/event_server.rb
@@ -20,4 +20,5 @@ EVENTS.subscribe('notify.user_updated') do |payload|
   puts 'DONE'
 end
 
-loop { sleep(100) }
+runner = Hanami::Events::Runner.new(EVENTS)
+runner.start


### PR DESCRIPTION
The old `loop { sleep(100) }` definition doesn't work anymore (due to gem code changes perhaps?)